### PR TITLE
maxWidth hack for Sway 1.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+build
+man
+config
+wk
+src/runtime/wayland/wlr-layer-shell-unstable-v1.*
+src/runtime/wayland/xdg-shell.c

--- a/src/runtime/wayland/wayland.c
+++ b/src/runtime/wayland/wayland.c
@@ -562,6 +562,7 @@ recreateWindows(Menu* menu, Wayland* wayland)
      */
     window->scale = 1;
     window->maxHeight = 640;
+    window->maxWidth = 640;
 
     struct wl_surface* surface = wl_compositor_create_surface(wayland->compositor);
     if (!surface) goto fail;


### PR DESCRIPTION
After I upgraded to Sway 1.10 to test out a new feature, I got buffer allocation errors from `wk`, which I traced down to a missing surface enter event, which resulted in `maxWidth` being set to 0, at least initially. I noticed that there was already a hack added in for the height, so I added a line for width and that fixed the issue and wk is operational again.

I also added a .gitignore file to filter out the build outputs. I can revert that if you are against that for some reason.