### PR TITLE
fix: respect wl_output transform on rotated outputs

### DIFF
--- a/src/runtime/wayland/registry.c
+++ b/src/runtime/wayland/registry.c
@@ -590,7 +590,7 @@ displayHandleDone(void* data, struct wl_output* output)
 static void
 displayHandleGeometry(
     void*             data,
-    struct wl_output* output,
+    struct wl_output* wlOut,
     int               x,
     int               y,
     int               physicalw,
@@ -600,8 +600,10 @@ displayHandleGeometry(
     const char*       model,
     int               transform)
 {
-    (void)data, (void)output, (void)x, (void)y, (void)physicalw,
-        (void)physicalh, (void)subpixel, (void)make, (void)model, (void)transform;
+    (void)wlOut, (void)x, (void)y, (void)physicalw, (void)physicalh,
+        (void)subpixel, (void)make, (void)model;
+    Output* output    = data;
+    output->transform = transform;
 }
 
 static void

--- a/src/runtime/wayland/wayland.c
+++ b/src/runtime/wayland/wayland.c
@@ -498,6 +498,22 @@ destroyWindows(Wayland* wayland)
     wl_list_init(&wayland->windows);
 }
 
+/* Odd wl_output transforms (90/270 and their flipped variants) swap mode dims. */
+static void
+outputLogicalSize(const Output* output, uint32_t* width, uint32_t* height)
+{
+    if (output->transform & 1)
+    {
+        *width  = output->height;
+        *height = output->width;
+    }
+    else
+    {
+        *width  = output->width;
+        *height = output->height;
+    }
+}
+
 static void
 windowUpdateOutput(WaylandWindow* window)
 {
@@ -511,13 +527,17 @@ windowUpdateOutput(WaylandWindow* window)
     wl_list_for_each(surfaceOutput, &window->surfaceOutputs, link)
     {
         if (surfaceOutput->output->scale > maxIntegerScale) maxIntegerScale = surfaceOutput->output->scale;
-        if (minMaxHeight == 0 || surfaceOutput->output->height < minMaxHeight)
+
+        uint32_t outputWidth, outputHeight;
+        outputLogicalSize(surfaceOutput->output, &outputWidth, &outputHeight);
+
+        if (minMaxHeight == 0 || outputHeight < minMaxHeight)
         {
-            minMaxHeight = surfaceOutput->output->height;
+            minMaxHeight = outputHeight;
         }
-        if (minMaxWidth == 0 || surfaceOutput->output->width < minMaxWidth)
+        if (minMaxWidth == 0 || outputWidth < minMaxWidth)
         {
-            minMaxWidth = surfaceOutput->output->width;
+            minMaxWidth = outputWidth;
         }
     }
 
@@ -608,13 +628,16 @@ fractionalScalePreferredScale(
     SurfaceOutput* surfaceOutput;
     wl_list_for_each(surfaceOutput, &window->surfaceOutputs, link)
     {
-        if (minMaxHeight == 0 || surfaceOutput->output->height < minMaxHeight)
+        uint32_t outputWidth, outputHeight;
+        outputLogicalSize(surfaceOutput->output, &outputWidth, &outputHeight);
+
+        if (minMaxHeight == 0 || outputHeight < minMaxHeight)
         {
-            minMaxHeight = surfaceOutput->output->height;
+            minMaxHeight = outputHeight;
         }
-        if (minMaxWidth == 0 || surfaceOutput->output->width < minMaxWidth)
+        if (minMaxWidth == 0 || outputWidth < minMaxWidth)
         {
-            minMaxWidth = surfaceOutput->output->width;
+            minMaxWidth = outputWidth;
         }
     }
 

--- a/src/runtime/wayland/wayland.h
+++ b/src/runtime/wayland/wayland.h
@@ -141,6 +141,7 @@ typedef struct
     struct wl_list    link;
     uint32_t          width;
     uint32_t          height;
+    int32_t           transform;
     int               scale;
     char*             name;
 } Output;


### PR DESCRIPTION
## Summary

On a portrait output (`wl_output` transform `90`/`270` or their flipped variants), wk ignores the transform field of `wl_output.geometry` and treats raw `wl_output.mode` dimensions as logical. The layer-shell `leftMargin = (maxWidth - menuWidth) / 2` is then computed against the unrotated sensor width, pushing the popup off the right edge of the actual logical output.

Concrete repro: 2560×1600 panel with transform `_270` and scale 1.0 has logical width 1600, but wk sees 2560 — `leftMargin` ends up 480px too wide.

## Fix

- Capture the transform in `displayHandleGeometry` and store it on `Output`.
- Resolve logical dimensions at the consumption sites (`windowUpdateOutput` and `fractionalScalePreferredScale`) via a small `outputLogicalSize()` helper that swaps width/height when `transform & 1`.

Resolving at consumption (rather than at `displayHandleMode`) keeps the state correct if the compositor re-emits geometry without re-emitting mode, which the `wl_output` event model allows.

## Verification

- [x] `make` clean (`-Wall -Wextra -Werror`).
- [x] Manual test on a rotated output (sway `output * transform 90`)