### PR TITLE
feat: add center menu position

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,6 +43,9 @@ key chords from a [wks](wks) file or script.
 **-b, --bottom**
 : Position menu at bottom of screen.
 
+**-c, --center**
+: Position menu at center of screen.
+
 **-s, --script**
 : Read **wks** script from stdin to use as key chords.
 

--- a/docs/reference/wks.md
+++ b/docs/reference/wks.md
@@ -887,6 +887,7 @@ Switch macros are simple toggles with no argument.
 | `:unsorted` | `--unsorted`        | Disable sorting         |
 | `:top`      | `--top`             | Position menu at top    |
 | `:bottom`   | `--bottom`          | Position menu at bottom |
+| `:center`   | `--center`          | Position menu at center |
 
 ### Integer Macros
 

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -464,11 +464,18 @@ disassembleMenu(const Menu* menu)
     debugMsgWithIndent(0, "| %-20s %04u", "Delay:", menu->delay);
     debugMsgWithIndent(0, "| %-20s %04u", "Keep Delay:", menu->keepDelay);
     debugMsgWithIndent(0, "| %-20s '%s'", "Wrap Cmd:", menu->wrapCmd ? menu->wrapCmd : "(null)");
+    const char* positionStr = "TOP";
+    switch (menu->position)
+    {
+    case MENU_POS_BOTTOM: positionStr = "BOTTOM"; break;
+    case MENU_POS_TOP:    positionStr = "TOP"; break;
+    case MENU_POS_CENTER: positionStr = "CENTER"; break;
+    }
     debugMsgWithIndent(
         0,
         "| %-20s %s",
         "Window position:",
-        (menu->position == MENU_POS_BOTTOM ? "BOTTOM" : "TOP"));
+        positionStr);
     debugMsgWithIndent(0, "| %-20s %s", "Debug:", "true");
     debugMsgWithIndent(0, "| %-20s %s", "Sort:", menu->sort ? "true" : "false");
     debugMsgWithIndent(0, "| %-20s %s", "Dirty:", menu->dirty ? "true" : "false");

--- a/src/common/menu.c
+++ b/src/common/menu.c
@@ -497,6 +497,7 @@ usage(void)
         "                               execution for +keep chords (default 75 ms).\n"
         "    -t, --top                  Position menu at top of screen.\n"
         "    -b, --bottom               Position menu at bottom of screen.\n"
+        "    -c, --center               Position menu at center of screen.\n"
         "    -s, --script               Read script from stdin to use as key chords.\n"
         "    -U, --unsorted             Disable sorting of key chords (sorted by default).\n"
         "    -m, --max-columns INT      Set the maximum menu columns to INT (defualt 5).\n"
@@ -586,6 +587,7 @@ menuParseArgs(Menu* menu, int* argc, char*** argv)
         { "debug",         no_argument,       0, 'd'                   },
         { "top",           no_argument,       0, 't'                   },
         { "bottom",        no_argument,       0, 'b'                   },
+        { "center",        no_argument,       0, 'c'                   },
         { "script",        no_argument,       0, 's'                   },
         { "unsorted",      no_argument,       0, 'U'                   },
         /*                  required argument           */
@@ -626,7 +628,7 @@ menuParseArgs(Menu* menu, int* argc, char*** argv)
     while (true)
     {
 
-        opt = getopt_long(*argc, *argv, ":hvdtbsUD:m:p:T:c:w:g:", longOpts, NULL);
+        opt = getopt_long(*argc, *argv, ":hvdtbcsUD:m:p:T:w:g:", longOpts, NULL);
         if (opt < 0) break;
 
         switch (opt)
@@ -637,6 +639,7 @@ menuParseArgs(Menu* menu, int* argc, char*** argv)
         case 'd': menu->debug = true; break;
         case 't': menu->position = MENU_POS_TOP; break;
         case 'b': menu->position = MENU_POS_BOTTOM; break;
+        case 'c': menu->position = MENU_POS_CENTER; break;
         case 's': menu->client.tryScript = true; break;
         case 'U': menu->sort = false; break;
         /* requires argument */

--- a/src/common/menu.h
+++ b/src/common/menu.h
@@ -52,7 +52,8 @@ typedef uint8_t MenuPosition;
 enum
 {
     MENU_POS_BOTTOM,
-    MENU_POS_TOP
+    MENU_POS_TOP,
+    MENU_POS_CENTER
 };
 
 typedef struct

--- a/src/compiler/preprocessor.c
+++ b/src/compiler/preprocessor.c
@@ -692,6 +692,7 @@ preprocessorRunImpl(
         case TOKEN_UNSORTED: menu->sort = false; break;
         case TOKEN_TOP: menu->position = MENU_POS_TOP; break;
         case TOKEN_BOTTOM: menu->position = MENU_POS_BOTTOM; break;
+        case TOKEN_CENTER: menu->position = MENU_POS_CENTER; break;
 
         /* Switches with signed integer args. */
         case TOKEN_MENU_WIDTH: /* FALLTHROUGH */

--- a/src/compiler/scanner.c
+++ b/src/compiler/scanner.c
@@ -410,6 +410,11 @@ scanPreprocessorMacro(Scanner* scanner, Token* token)
         else if (isKeyword(scanner, 1, 1, "d")) result = TOKEN_BORDER_COLOR;
         break;
     }
+    case 'c':
+    {
+        if (isKeyword(scanner, 1, 5, "enter")) result = TOKEN_CENTER;
+        break;
+    }
     case 'd':
     {
         if (isKeyword(scanner, 1, 4, "ebug")) result = TOKEN_DEBUG;

--- a/src/compiler/token.c
+++ b/src/compiler/token.c
@@ -54,6 +54,7 @@ static const TokenTable tokenTable[TOKEN_LAST] = {
     [TOKEN_UNSORTED] = "TOKEN_UNSORTED",
     [TOKEN_TOP]      = "TOKEN_TOP",
     [TOKEN_BOTTOM]   = "TOKEN_BOTTOM",
+    [TOKEN_CENTER]   = "TOKEN_CENTER",
 
     /* [-]integer macros */
     [TOKEN_MENU_WIDTH] = "TOKEN_MENU_WIDTH",

--- a/src/compiler/token.h
+++ b/src/compiler/token.h
@@ -49,6 +49,7 @@ enum
     TOKEN_UNSORTED,
     TOKEN_TOP,
     TOKEN_BOTTOM,
+    TOKEN_CENTER,
 
     /* [-]integer macros */
     TOKEN_MENU_WIDTH,

--- a/src/runtime/wayland/window.c
+++ b/src/runtime/wayland/window.c
@@ -261,7 +261,7 @@ getAlignAnchor(MenuPosition position)
     {
         anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
     }
-    else
+    else if (position == MENU_POS_TOP)
     {
         anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
     }
@@ -393,6 +393,15 @@ moveResizeWindow(WaylandWindow* window, Buffer* buffer, struct wl_display* displ
             0,
             0,
             window->windowGap,
+            leftMargin);
+    }
+    else if (window->position == MENU_POS_CENTER)
+    {
+        zwlr_layer_surface_v1_set_margin(
+            window->layerSurface,
+            0,
+            0,
+            0,
             leftMargin);
     }
     else

--- a/src/runtime/x11/window.c
+++ b/src/runtime/x11/window.c
@@ -206,6 +206,10 @@ resizeWinHeight(X11Window* window, Menu* menu)
     {
         window->y = root->h - window->height - window->y + root->y;
     }
+    else if (desiriedPos(menu, MENU_POS_CENTER))
+    {
+        window->y = root->y + (root->h - window->height) / 2;
+    }
 }
 
 static void


### PR DESCRIPTION
## Summary

Adds a `--center` CLI flag (and `:center` chord-file macro) to pin the popup to the center of the screen, alongside the existing `--top` and `--bottom`. Useful for transient which-key style popups where neither edge fits.

## Changes

- New `MENU_POS_CENTER` enum + scanner/preprocessor token + CLI / macro plumbing.
- Wayland: `getAlignAnchor` returns just `LEFT|RIGHT` for CENTER, so the compositor centres on the unanchored vertical axis. `moveResizeWindow` adds a matching margin branch.
- X11: `resizeWinHeight` adds a CENTER branch; horizontal centring is already unconditional in `resizeWinWidth`.
- Reused the dead `c:` slot in the getopt short string — it was listed but had no `case 'c':` handler and no long-alias.

## Compatibility

Default `menuPosition` is unchanged at `0` (BOTTOM). Existing configs and CLI invocations behave identically.

## Verification

- [x] `make` clean (`-Wall -Wextra -Werror`).
- [x] Manual test on Wayland (cosmic-comp)
- [ ] Manual test on X11 